### PR TITLE
update to package installer for hurricaneexposuredata

### DIFF
--- a/code/lab/package_installer.R
+++ b/code/lab/package_installer.R
@@ -74,27 +74,17 @@ pkgs <- c("BiocManager", "cartogram", "corrr", "dplyr", "explore", "fst",
           "mgcv", "pacman", "patchwork", "psych", "purrr", "raster", 
           "RColorBrewer", "readr", "remotes", "rlang", "tmap", "sf", "spdep", 
           "stringr", "Synth", "terra", "tidyr", "usethis", "viridis", 
-          "weathermetrics", "conflicted")
+          "weathermetrics", "conflicted", "drat")
 pkg_inst(pkgs)
 
-# Since rgdal is deprecated we need to install the last version in the archive.
-# See: https://cran.r-project.org/web/packages/rgdal/index.html
-# And: https://stackoverflow.com/questions/76868135/
-options("rgdal_show_exportToProj4_warnings" = "none")
-if (!requireNamespace("rgdal", quietly = TRUE)) 
-  remotes::install_version("rgdal", version = "1.6-7")
-
-# Since rgeos is deprecated we need to install the last version in the archive.
-# See: https://cran.r-project.org/web/packages/rgeos/index.html
-# And: https://stackoverflow.com/questions/77687036/
-if (!requireNamespace("rgeos", quietly = TRUE)) 
-  remotes::install_version("rgeos", version = "0.6-4")
 
 # Install and load the tidysynth & hurricaneexposure packages from Github
 if (!requireNamespace("tidysynth", quietly = TRUE)) 
   pak::pkg_install("edunford/tidysynth")
 if (!requireNamespace("hurricaneexposure", quietly = TRUE)) 
   pak::pkg_install("geanders/hurricaneexposure")
-if (!requireNamespace("hurricaneexposuredata", quietly = TRUE)) 
-  pak::pkg_install("geanders/hurricaneexposuredata")
+
+addRepo("geanders")
+pacman::p_load("hurricaneexposuredata")
+
 

--- a/code/lab/package_installer.R
+++ b/code/lab/package_installer.R
@@ -84,6 +84,7 @@ if (!requireNamespace("tidysynth", quietly = TRUE))
 if (!requireNamespace("hurricaneexposure", quietly = TRUE)) 
   pak::pkg_install("geanders/hurricaneexposure")
 
+library("drat")
 addRepo("geanders")
 pacman::p_load("hurricaneexposuredata")
 


### PR DESCRIPTION
Hi Brian -- Joan and I discussed and I updated the installer script to get rid of `rgdal` and `rgeo` which no longer work/we don't need anymore, and also added in an extra line to facilitate `hurricaneexposuredata` package because the install from last year no longer works. I have tested these installs and all seems good! Just tagging you both as an FYI for the installer script -- Brian please let us know if you see any issues with the changes and if not ill go ahead and merge in!! 

Thanks,
L